### PR TITLE
Updates to build libecbufr on OSX 13

### DIFF
--- a/API/Sources/bufr_desc.c
+++ b/API/Sources/bufr_desc.c
@@ -41,7 +41,7 @@ This file is part of libECBUFR.
 #include "private/gcmemory.h"
 #include "config.h"
 
-static caddr_t  BufrDescriptor_gcmemory=NULL;
+static void * BufrDescriptor_gcmemory=NULL;
 
 
 static int bufr_check_class31_set( BufrDescriptor *cb );

--- a/API/Sources/bufr_linklist.c
+++ b/API/Sources/bufr_linklist.c
@@ -25,7 +25,7 @@ This file is part of libECBUFR.
 #include "private/gcmemory.h"
 #include "config.h"
 
-static caddr_t  ListNode_gcmemory=NULL;
+static void *  ListNode_gcmemory=NULL;
 
 
 /**************************************************************************

--- a/API/Sources/bufr_value.c
+++ b/API/Sources/bufr_value.c
@@ -40,13 +40,13 @@ This file is part of libECBUFR.
 #include "private/gcmemory.h"
 #include "config.h"
 
-static caddr_t  ValueINT8_gcmemory=NULL;
-static caddr_t  ValueINT16_gcmemory=NULL;
-static caddr_t  ValueINT32_gcmemory=NULL;
-static caddr_t  ValueINT64_gcmemory=NULL;
-static caddr_t  ValueFLT32_gcmemory=NULL;
-static caddr_t  ValueFLT64_gcmemory=NULL;
-static caddr_t  ValueSTRING_gcmemory=NULL;
+static void * ValueINT8_gcmemory=NULL;
+static void * ValueINT16_gcmemory=NULL;
+static void * ValueINT32_gcmemory=NULL;
+static void * ValueINT64_gcmemory=NULL;
+static void * ValueFLT32_gcmemory=NULL;
+static void * ValueFLT64_gcmemory=NULL;
+static void * ValueSTRING_gcmemory=NULL;
 
 /**
  * @english

--- a/API/Sources/gcmemory.c
+++ b/API/Sources/gcmemory.c
@@ -26,7 +26,6 @@ This file is part of libECBUFR.
 
 
 #include <stdio.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 #include "private/gcmemory.h"


### PR DESCRIPTION
This is an implementation of the changes @topher800 mentioned in #99. With these changes, libecbufr builds on OSX 13.2.1 on my M1 mac, using clang from homebrew. 