### PR TITLE
fix a memory leak caused by not freeing existing RTMD

### DIFF
--- a/API/Sources/bufr_sequence.c
+++ b/API/Sources/bufr_sequence.c
@@ -2306,6 +2306,7 @@ static void bufr_transfer_rtmd
    while ( node )
       {
       cb = (BufrDescriptor *)node->data;
+		if( cb->meta ) bufr_free_rtmd(cb->meta);
       cb->meta = bufr_duplicate_rtmd( rtmd );
       node = lst_nextnode( node );
       }


### PR DESCRIPTION
fix a memory leak caused by not freeing existing RTMD when duplicating RTMD from something else. It doesn't happen for every product, but the 307091 template appears to trigger it reliably. The memcheck call stack for the leak tends to look something like:

==543602== 80 bytes in 20 blocks are indirectly lost in loss record 1 of 2
==543602==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==543602==    by 0x4856E74: bufr_create_rtmd (bufr_meta.c:63)
==543602==    by 0x4856EDA: bufr_duplicate_rtmd (bufr_meta.c:100)
==543602==    by 0x485A3A7: bufr_copy_descriptor (bufr_desc.c:282)
==543602==    by 0x485A1C3: bufr_dupl_descriptor (bufr_desc.c:206)
==543602==    by 0x485CF5F: bufr_repl_descriptors (bufr_sequence.c:599)
==543602==    by 0x485C3B2: bufr_expand_node_descriptor (bufr_sequence.c:354)
==543602==    by 0x485BD56: bufr_expand_list (bufr_sequence.c:201)
==543602==    by 0x485C167: bufr_expand_desc (bufr_sequence.c:311)
==543602==    by 0x485C8F4: bufr_expand_node_descriptor (bufr_sequence.c:438)
==543602==    by 0x485BD56: bufr_expand_list (bufr_sequence.c:201)
==543602==    by 0x485D27B: bufr_repl_descriptors (bufr_sequence.c:671)
==543602==    by 0x485C6C8: bufr_expand_node_descriptor (bufr_sequence.c:402)
==543602==    by 0x486F81A: bufr_decode_message (bufr_dataset.c:2413)
==543602==    by 0x10B9AD: run_decoder (bufr_decoder.c:365)
==543602==    by 0x10B4F5: main (bufr_decoder.c:245)
==543602==
==543602== 1,200 (1,120 direct, 80 indirect) bytes in 20 blocks are definitely lost in loss record 2 of 2
==543602==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==543602==    by 0x4856E40: bufr_create_rtmd (bufr_meta.c:58)
==543602==    by 0x4856EDA: bufr_duplicate_rtmd (bufr_meta.c:100)
==543602==    by 0x485A3A7: bufr_copy_descriptor (bufr_desc.c:282)
==543602==    by 0x485A1C3: bufr_dupl_descriptor (bufr_desc.c:206)
==543602==    by 0x485CF5F: bufr_repl_descriptors (bufr_sequence.c:599)
==543602==    by 0x485C3B2: bufr_expand_node_descriptor (bufr_sequence.c:354)
==543602==    by 0x485BD56: bufr_expand_list (bufr_sequence.c:201)
==543602==    by 0x485C167: bufr_expand_desc (bufr_sequence.c:311)
==543602==    by 0x485C8F4: bufr_expand_node_descriptor (bufr_sequence.c:438)
==543602==    by 0x485BD56: bufr_expand_list (bufr_sequence.c:201)
==543602==    by 0x485D27B: bufr_repl_descriptors (bufr_sequence.c:671)
==543602==    by 0x485C6C8: bufr_expand_node_descriptor (bufr_sequence.c:402)
==543602==    by 0x486F81A: bufr_decode_message (bufr_dataset.c:2413)
==543602==    by 0x10B9AD: run_decoder (bufr_decoder.c:365)
==543602==    by 0x10B4F5: main (bufr_decoder.c:245)